### PR TITLE
Fix index OHLC parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2025-06-25
+
+### Fixed
+- **Index Quote Parsing**: Correct field order for index OHLC data and parse
+  the `net_change` field directly.
+
+## [0.1.3] - 2025-06-25
+
+### Fixed
+- **Index Quotes Parsing**: Properly parse the `net_change` field for index
+  ticks and document the difference in the OHLC payload.
+
 ## [0.1.2] - 2025-06-21
 
 ### Removed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Kaushik Chakraborty <git@kaushikc.org>", "Shaun Pai <shauna.pai@gmail.com>"]
 name = "kiteticker-async-manager"
-version = "0.1.2"
+version = "0.1.4"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -157,6 +157,18 @@ pub struct OHLC {
 }
 ```
 
+For **index quotes**, the streaming payload includes an additional
+`net_change` value immediately after the OHLC bytes. The order of the
+OHLC fields also differs:
+
+```
+Index quotes:  High, Low, Open, Close
+Other quotes:  Open, High, Low, Close
+```
+
+This library parses the `net_change` field directly and accounts for the
+different field order when constructing the [`OHLC`] struct.
+
 ### `MarketDepth`
 
 Order book depth data (Full mode only).

--- a/src/models/ohlc.rs
+++ b/src/models/ohlc.rs
@@ -27,4 +27,20 @@ impl OHLC {
       None
     }
   }
+
+  /// Parse OHLC bytes for index instruments.
+  ///
+  /// The order of fields for indices is `high`, `low`, `open`, `close`.
+  pub(crate) fn from_index(value: &[u8], exchange: &Exchange) -> Option<Self> {
+    if let Some(bs) = value.get(0..16) {
+      Some(OHLC {
+        open: price(&bs[8..=11], exchange).unwrap(),
+        high: price(&bs[0..=3], exchange).unwrap(),
+        low: price(&bs[4..=7], exchange).unwrap(),
+        close: price(&bs[12..=15], exchange).unwrap(),
+      })
+    } else {
+      None
+    }
+  }
 }

--- a/src/models/tick.rs
+++ b/src/models/tick.rs
@@ -83,11 +83,10 @@ impl Tick {
       if is_index {
         if let Some(bs) = i.get(8..28) {
           t.mode = Mode::Quote;
-          // 8 - 24 bytes : ohlc
-          t.ohlc = OHLC::from(&bs[0..16], &t.exchange);
-          // 24 - 28 bytes : Price change
-          // t.net_change = price(&bs[16..=19], &t.exchange);
-          t.set_change();
+          // 8 - 24 bytes : ohlc (indices use HLOC order)
+          t.ohlc = OHLC::from_index(&bs[0..16], &t.exchange);
+          // 24 - 28 bytes : price change (provided only for indices)
+          t.net_change = price(&bs[16..20], &t.exchange);
         }
       } else {
         if let Some(bs) = i.get(8..44) {


### PR DESCRIPTION
## Summary
- correct field ordering for index OHLC bytes
- parse net_change directly for index quotes
- document index OHLC order difference
- bump version to 0.1.4 and update changelog

## Testing
- `cargo check` *(fails: failed to download from `index.crates.io`)*

------
https://chatgpt.com/codex/tasks/task_e_685b740a5ec083339cb1dc2f3850d18f